### PR TITLE
Add gnustep-base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,15 @@ jobs:
       - name: Install libdispatch
         run: ../.python3/bin/conan create . --profile:a=$(pwd)/../profiles/linux-clang
         working-directory: libdispatch/
+      - name: Install gnustep-base dependencies (Ubuntu)
+        run: |
+          apt-get update
+          apt-get install -y libffi-dev libxml2-dev libxslt-dev gnutls-dev libicu-dev libcurl4-gnutls-dev
+        if: matrix.family == 'ubuntu'
+      - name: Install gnustep-base dependencies (Enterprise Linux)
+        run: |
+          yum install -y libffi-devel libxml2-devel libxslt-devel gnutls-devel libicu-devel libcurl-devel
+        if: matrix.family == 'rhel'
       - name: Install gnustep-base
         run: ../.python3/bin/conan create . --profile:a=$(pwd)/../profiles/linux-clang
         working-directory: gnustep-base/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Remove conflicting copies of make
+        # The runners include a copy of mingw64, and explicitly add mingw64's copy of make.exe to PATH. This
+        # will cause the build to fail.  Remove mingw64 alltogether.
+        # See https://github.com/actions/runner-images/blob/main/images/windows/scripts/build/Install-Mingw64.ps1#L63-L67
+        # The same goes for C:\Strawberry\*\bin, which contains copy of make, pkg-config, and gdb
+        shell: cmd
+        run: |
+          rmdir /q /s C:\mingw64\bin\
+          rmdir /q /s C:\Strawberry\c\bin\
+          rmdir /q /s C:\Strawberry\perl\bin\
       - name: Check LLVM version
         # We need at least LLVM 18.0 for proper Objective C support.  Visual Studio 2022 ships with LLVM 17,
         # so we need to make sure we pick up clang from C:\Program Files\LLVM\bin\

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Install libdispatch
         run: conan create . --profile:a=${{ github.workspace }}/profiles/windows-clang
         working-directory: libdispatch/
+      - name: Install gnustep-base
+        run: conan create . --profile:a=${{ github.workspace }}/profiles/windows-clang
+        working-directory: gnustep-base/
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,9 @@ jobs:
       - name: Install libdispatch
         run: ../.python3/bin/conan create . --profile:a=$(pwd)/../profiles/linux-clang
         working-directory: libdispatch/
+      - name: Install gnustep-base
+        run: ../.python3/bin/conan create . --profile:a=$(pwd)/../profiles/linux-clang
+        working-directory: gnustep-base/
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,18 @@
                 "${workspaceFolder}/gnustep-make/conanfile.py",
                 "--profile:a=${workspaceFolder}/profiles/linux-clang"
             ],
+        },
+        {
+            "name": "gnustep-base",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "conans.conan",
+            "justMyCode": false,
+            "args": [
+                "create",
+                "${workspaceFolder}/gnustep-base/conanfile.py",
+                "--profile:a=${workspaceFolder}/profiles/linux-clang"
+            ],
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,47 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+        "label": "Create libobjc2",
+        "type": "process",
+        "command": "C:\\Program Files\\Conan\\conan\\conan.exe",
+        "args": [
+            "create",
+            "${workspaceFolder}/libobjc2/",
+            "--profile:a=${workspaceFolder}/profiles/windows-clang"
+        ]
+    },
+    {
+        "label": "Create libdispatch",
+        "type": "process",
+        "command": "C:\\Program Files\\Conan\\conan\\conan.exe",
+        "args": [
+            "create",
+            "${workspaceFolder}/libdispatch/",
+            "--profile:a=${workspaceFolder}/profiles/windows-clang"
+        ]
+    },
+    {
+        "label": "Create gnustep-make",
+        "type": "process",
+        "command": "C:\\Program Files\\Conan\\conan\\conan.exe",
+        "args": [
+            "create",
+            "${workspaceFolder}/gnustep-make/",
+            "--profile:a=${workspaceFolder}/profiles/windows-clang"
+        ]
+    },
+    {
+        "label": "Create gnustep-base",
+        "type": "process",
+        "command": "C:\\Program Files\\Conan\\conan\\conan.exe",
+        "args": [
+            "create",
+            "${workspaceFolder}/gnustep-base/",
+            "--profile:a=${workspaceFolder}/profiles/windows-clang"
+        ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Cross-platform build tools for GNUstep
+
+This repository contains [Conan](https://conan.io/) support for building [GNUstep](https://gnustep.github.io/) on Windows and Linux.
+
+It contains:
+- [Conan recipes](https://docs.conan.io/2/reference/conanfile.html) for building [libobjc2](https://github.com/gnustep/libobjc2), [libdispatch](https://github.com/apple/swift-corelibs-libdispatch/), [gnustep-make](https://github.com/gnustep/tools-make) and [gnustep-base](https://github.com/gnustep/libs-base)
+- [Conan profiles](https://docs.conan.io/2/reference/config_files/profiles.html) for building using clang on Windows and Linux
+
+On Windows, this repository takes the approach of building GNUstep using the Windows-native LLVM (clang) compiler. It uses MSYS2 to get a Bash shell, which allows running the scripts required to configure and build GNUstep, and does not use the MSYS2 compiler toolchain.
+
+## Getting started on Windows
+On Windows, you'll need to download the Windows SDK and the LLVM toolchain. Optionally, you can use Visual Studio Code as an editor and Git for source code interations.
+
+- [Visual Studio 2022 Build Tools (Windows SDK)](https://visualstudio.microsoft.com/downloads/)
+- [LLVM 20.0 or later](https://releases.llvm.org/download.html)
+- [Git for Windows](https://git-scm.com/download/win)
+- [Conan](https://conan.io/downloads)
+
+To get started, run the following commands:
+
+```
+bash
+git clone https://github.com/qmfrederik/conan-gnustep/
+cd conan-gnustep
+conan create libobjc2 --profile:a=profiles/windows-clang
+conan create libdispatch --profile:a=profiles/windows-clang
+conan create gnustep-make --profile:a=profiles/windows-clang
+conan create gnustep-base --profile:a=profiles/windows-clang
+```
+
+This will configure GNUstep Base and all of its dependencies.

--- a/gnustep-base/0001-Support-libcurl-7.61.patch
+++ b/gnustep-base/0001-Support-libcurl-7.61.patch
@@ -1,0 +1,145 @@
+From baaeb2bd4c198bc7a10c8e1c46ba5ca7be43469e Mon Sep 17 00:00:00 2001
+From: Frederik Carlier <frederik.carlier@keysight.com>
+Date: Thu, 3 Jul 2025 22:24:46 +0200
+Subject: [PATCH 1/2] Support libcurl 7.61
+
+This version of libcurl ships with RHEL 8
+---
+ Source/NSURLSessionConfiguration.m | 10 ++++++++++
+ Source/NSURLSessionTask.m          |  4 ++++
+ configure                          | 12 ++++++------
+ configure.ac                       |  8 ++++----
+ 4 files changed, 24 insertions(+), 10 deletions(-)
+
+diff --git a/Source/NSURLSessionConfiguration.m b/Source/NSURLSessionConfiguration.m
+index 2f4172207..856dd87c1 100644
+--- a/Source/NSURLSessionConfiguration.m
++++ b/Source/NSURLSessionConfiguration.m
+@@ -27,9 +27,12 @@
+  * Software Foundation, Inc., 31 Milk Street #960789 Boston, MA 02196 USA.
+  */
+ 
++#import "Foundation/NSException.h"
+ #import "Foundation/NSURLSession.h"
+ #import "Foundation/NSHTTPCookie.h"
+ 
++#include <curl/curl.h>
++
+ // TODO: This is the old implementation. It requires a rewrite!
+ 
+ @implementation NSURLSessionConfiguration
+@@ -166,7 +169,14 @@ static NSURLSessionConfiguration * def = nil;
+ 
+ - (void) setHTTPMaximumConnectionLifetime: (NSInteger)n
+ {
++#if CURL_AT_LEAST_VERSION(7, 66, 0)
+   _HTTPMaximumConnectionLifetime = n;
++#else
++  [NSException raise: NSInternalInconsistencyException
++    format: @"-[%@ %@] not supported by the version of Curl"
++    @" this library was built with",
++    NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
++#endif
+ }
+ 
+ - (BOOL) HTTPShouldUsePipelining
+diff --git a/Source/NSURLSessionTask.m b/Source/NSURLSessionTask.m
+index 0f0ccef62..820b2b287 100644
+--- a/Source/NSURLSessionTask.m
++++ b/Source/NSURLSessionTask.m
+@@ -174,7 +174,9 @@ errorForCURLcode(CURL *handle, CURLcode code, char errorBuffer[CURL_ERROR_SIZE])
+       case CURLE_COULDNT_RESOLVE_HOST:
+         urlError = NSURLErrorDNSLookupFailed;
+         break;
++#if CURL_AT_LEAST_VERSION(7, 69, 0)
+       case CURLE_QUIC_CONNECT_ERROR:
++#endif
+       case CURLE_COULDNT_CONNECT:
+         urlError = NSURLErrorCannotConnectToHost;
+         break;
+@@ -1048,10 +1050,12 @@ write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+       /* Set to HTTP/3 if requested */
+       if ([request assumesHTTP3Capable])
+         {
++#if CURL_AT_LEAST_VERSION(7, 66, 0)
+           curl_easy_setopt(
+             _easyHandle,
+             CURLOPT_HTTP_VERSION,
+             CURL_HTTP_VERSION_3);
++#endif
+         }
+ 
+       /* Configure the custom CA certificate if available */
+diff --git a/configure b/configure
+index 4a0c042e5..db685622f 100755
+--- a/configure
++++ b/configure
+@@ -14628,9 +14628,9 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null && test "$SKIP_CURL_CONFIG
+   curl_ver=`$CURL_CONFIG --version | sed -e "s/libcurl //g"`
+   curl_maj=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\1/"`
+   curl_min=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\2/"`
+-  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 66 \); then
+-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use" >&5
+-printf "%s\n" "FAILED (version too old to use" >&6; }
++  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 61 \); then
++    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version $curl_ver too old to use, need at least 7.61)" >&5
++printf "%s\n" "FAILED (version $curl_ver too old to use, need at least 7.61)" >&6; }
+   else
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes ... version $curl_ver" >&5
+ printf "%s\n" "yes ... version $curl_ver" >&6; }
+@@ -14660,7 +14660,7 @@ else
+     if pkg-config --exists libcurl; then
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes ... via pkg-config" >&5
+ printf "%s\n" "yes ... via pkg-config" >&6; }
+-      if $PKG_CONFIG --atleast-version 2.66.0 libcurl; then
++      if $PKG_CONFIG --atleast-version 7.61.0 libcurl; then
+                for ac_header in curl/curl.h
+ do :
+   ac_fn_c_check_header_compile "$LINENO" "curl/curl.h" "ac_cv_header_curl_curl_h" "$ac_includes_default"
+@@ -14682,8 +14682,8 @@ done
+           curl_all=yes
+         fi
+         else
+-          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use" >&5
+-printf "%s\n" "FAILED (version too old to use" >&6; }
++          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: FAILED (version too old to use, need at least 7.61)" >&5
++printf "%s\n" "FAILED (version too old to use, need at least 7.61)" >&6; }
+           curl_all=no
+       fi
+     else
+diff --git a/configure.ac b/configure.ac
+index 691188e29..781c12040 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3746,8 +3746,8 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null && test "$SKIP_CURL_CONFIG
+   curl_ver=`$CURL_CONFIG --version | sed -e "s/libcurl //g"`
+   curl_maj=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\1/"`
+   curl_min=`echo $curl_ver | sed -e "s/^\(.*\)\.\(.*\)\.\(.*\)$/\2/"`
+-  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 66 \); then
+-    AC_MSG_RESULT([FAILED (version too old to use])
++  if test $curl_maj -lt 7 -o \( $curl_maj -eq 7 -a $curl_min -lt 61 \); then
++    AC_MSG_RESULT([FAILED (version $curl_ver too old to use, need at least 7.61)])
+   else
+     AC_MSG_RESULT(yes ... version $curl_ver)
+     AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
+@@ -3764,7 +3764,7 @@ else
+   if test -n "$PKG_CONFIG"; then
+     if pkg-config --exists libcurl; then
+       AC_MSG_RESULT(yes ... via pkg-config)
+-      if $PKG_CONFIG --atleast-version 2.66.0 libcurl; then
++      if $PKG_CONFIG --atleast-version 7.61.0 libcurl; then
+         AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
+         if test "$curl_ok" = yes; then
+           HAVE_LIBCURL=1
+@@ -3775,7 +3775,7 @@ else
+           curl_all=yes
+         fi
+         else
+-          AC_MSG_RESULT([FAILED (version too old to use])
++          AC_MSG_RESULT([FAILED (version too old to use, need at least 7.61)])
+           curl_all=no
+       fi
+     else
+-- 
+2.43.0
+

--- a/gnustep-base/0002-expose-declarations-in-NSDebug.h-even-when-NDEBUG-is.patch
+++ b/gnustep-base/0002-expose-declarations-in-NSDebug.h-even-when-NDEBUG-is.patch
@@ -1,0 +1,35 @@
+From 907cdf033f087247ea5141c70f98efd8d0eb4ea4 Mon Sep 17 00:00:00 2001
+From: ethanc8 <echaroenpitaks@gmail.com>
+Date: Sun, 22 Jun 2025 13:31:44 -0500
+Subject: [PATCH 2/2] expose declarations in NSDebug.h even when NDEBUG is
+ defined
+
+---
+ Headers/Foundation/NSDebug.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Headers/Foundation/NSDebug.h b/Headers/Foundation/NSDebug.h
+index dd0ad1153..29cc565b0 100644
+--- a/Headers/Foundation/NSDebug.h
++++ b/Headers/Foundation/NSDebug.h
+@@ -115,8 +115,6 @@ extern "C" {
+  */
+ extern BOOL NSDebugEnabled;
+ 
+-#ifndef	NDEBUG
+-
+ /**
+  * Used internally by NSAllocateObject() ... you probably don't need this.
+  */
+@@ -321,8 +319,6 @@ GS_EXPORT void  GSSetDebugAllocationFunctions(
+   void (*newAddObjectFunc)(Class c, id o),
+   void (*newRemoveObjectFunc)(Class c, id o));
+ 
+-#endif
+-
+ /**
+  * Enable/disable zombies.
+  * <p>When an object is deallocated, its isa pointer is normally modified
+-- 
+2.43.0
+

--- a/gnustep-base/0003-Use-PKG_CONFIG-to-invoke-pkg-config.patch
+++ b/gnustep-base/0003-Use-PKG_CONFIG-to-invoke-pkg-config.patch
@@ -1,0 +1,94 @@
+From 0a7e4d366001859864003786633cdc8c71435d99 Mon Sep 17 00:00:00 2001
+From: Frederik Carlier <frederik.carlier@keysight.com>
+Date: Tue, 8 Jul 2025 20:18:56 +0200
+Subject: [PATCH 3/3] Use $PKG_CONFIG to invoke pkg-config
+
+This ensures consistency within the configure script, and  allows users to override the exact version of pkg-config which is being used.  This allows for the use of  alternatives, such as pkgconf.
+---
+ configure    | 8 ++++----
+ configure.ac | 8 ++++----
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/configure b/configure
+index db685622f..63a5a9a10 100755
+--- a/configure
++++ b/configure
+@@ -12205,7 +12205,7 @@ printf "%s\n" "#define USE_LIBFFI 1" >>confdefs.h
+ 
+   WITH_FFI=libffi
+   if test "$pkg_config_libffi" = "yes"; then
+-    ffi_LIBS=`pkg-config --libs libffi`
++    ffi_LIBS=`$PKG_CONFIG --libs libffi`
+   else
+     ffi_LIBS=-lffi
+   fi
+@@ -13676,7 +13676,7 @@ if test $enable_tls = yes; then
+   saved_CFLAGS="$CFLAGS"
+ 
+   if test -n "$PKG_CONFIG"; then
+-    if pkg-config --exists gnutls; then
++    if $PKG_CONFIG --exists gnutls; then
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking gnutls support" >&5
+ printf %s "checking gnutls support... " >&6; }
+       HAVE_GNUTLS=1
+@@ -13923,7 +13923,7 @@ printf "%s\n" "no" >&6; }
+     fi
+   fi
+   if test $HAVE_GNUTLS = 1; then
+-    if ! pkg-config --atleast-version=2.12 gnutls; then
++    if ! $PKG_CONFIG --atleast-version=2.12 gnutls; then
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gcry_control in -lgcrypt" >&5
+ printf %s "checking for gcry_control in -lgcrypt... " >&6; }
+ if test ${ac_cv_lib_gcrypt_gcry_control+y}
+@@ -14657,7 +14657,7 @@ done
+   fi
+ else
+   if test -n "$PKG_CONFIG"; then
+-    if pkg-config --exists libcurl; then
++    if $PKG_CONFIG --exists libcurl; then
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes ... via pkg-config" >&5
+ printf "%s\n" "yes ... via pkg-config" >&6; }
+       if $PKG_CONFIG --atleast-version 7.61.0 libcurl; then
+diff --git a/configure.ac b/configure.ac
+index 781c12040..b89381607 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3114,7 +3114,7 @@ if test $enable_libffi = yes; then
+             [Define if using the libffi library for invocations])
+   WITH_FFI=libffi
+   if test "$pkg_config_libffi" = "yes"; then
+-    ffi_LIBS=`pkg-config --libs libffi`
++    ffi_LIBS=`$PKG_CONFIG --libs libffi`
+   else
+     ffi_LIBS=-lffi
+   fi
+@@ -3467,7 +3467,7 @@ if test $enable_tls = yes; then
+   saved_CFLAGS="$CFLAGS"
+ 
+   if test -n "$PKG_CONFIG"; then
+-    if pkg-config --exists gnutls; then
++    if $PKG_CONFIG --exists gnutls; then
+       AC_MSG_CHECKING(gnutls support)
+       HAVE_GNUTLS=1
+       TLS_CFLAGS=`$PKG_CONFIG --cflags gnutls`
+@@ -3485,7 +3485,7 @@ if test $enable_tls = yes; then
+     fi
+   fi
+   if test $HAVE_GNUTLS = 1; then
+-    if ! pkg-config --atleast-version=2.12 gnutls; then
++    if ! $PKG_CONFIG --atleast-version=2.12 gnutls; then
+       AC_CHECK_LIB(gcrypt, gcry_control, have_gcrypt=yes, have_gcrypt=no)
+       if test "$have_gcrypt" = "no"; then
+         HAVE_GNUTLS=0
+@@ -3762,7 +3762,7 @@ if eval $CURL_CONFIG --version 2>/dev/null >/dev/null && test "$SKIP_CURL_CONFIG
+   fi
+ else
+   if test -n "$PKG_CONFIG"; then
+-    if pkg-config --exists libcurl; then
++    if $PKG_CONFIG --exists libcurl; then
+       AC_MSG_RESULT(yes ... via pkg-config)
+       if $PKG_CONFIG --atleast-version 7.61.0 libcurl; then
+         AC_CHECK_HEADERS(curl/curl.h, curl_ok=yes, curl_ok=no)
+-- 
+2.50.0.windows.1
+

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
-from conan.tools.files import get
-from conan.tools.microsoft import unix_path
+from conan.tools.files import get, patch
 import os
 
 class GnustepBaseRecipe(ConanFile):
@@ -16,10 +15,15 @@ class GnustepBaseRecipe(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": True, "fPIC": True}
+    exports_sources = "*.patch"
 
     def source(self):
         get(self, "https://github.com/gnustep/libs-base/releases/download/base-1_31_1/gnustep-base-1.31.1.tar.gz",
                   strip_root=True)
+
+        # These patches are maintained at https://github.com/qmfrederik/libs-base/tree/base-1_31_1-PACKAGE
+        patch(self, patch_file=os.path.join(self.export_sources_folder, "0001-Support-libcurl-7.61.patch"))
+        patch(self, patch_file=os.path.join(self.export_sources_folder, "0002-expose-declarations-in-NSDebug.h-even-when-NDEBUG-is.patch"))
 
     def requirements(self):
         self.requires("libobjc2/2.2.1")
@@ -65,6 +69,7 @@ class GnustepBaseRecipe(ConanFile):
 
         # Resolve GNUstep makefiles
         tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_make_package_folder}/share/GNUstep/Makefiles/")
+        tc.make_args.append(f"GNUSTEP_MAKEFILES={gnustep_make_package_folder}/share/GNUstep/Makefiles/")
         tc.configure_args.append("--disable-importing-config-file")
         tc.generate(env)
 

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -95,6 +95,7 @@ class GnustepBaseRecipe(ConanFile):
 
         # Resolve GNUstep makefiles
         tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_makefiles_folder}")
+        tc.make_args.append(f"GNUSTEP_MAKEFILES={gnustep_makefiles_folder}")
         tc.configure_args.append("--disable-importing-config-file")
 
         # Force the use of a relative value for srcdir.  Some configure checks will inject

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
-from conan.tools.files import get, patch
+from conan.tools.files import get, patch, replace_in_file
 import os
 
 class GnustepBaseRecipe(ConanFile):
@@ -111,6 +111,9 @@ class GnustepBaseRecipe(ConanFile):
             # checking target system type... x86_64-pc-windows
             tc.configure_args.append(f"--host=x86_64-pc-windows")
             tc.configure_args.append(f"--target=x86_64-pc-windows")
+
+            # This appears to be a Conan bug, the library name for libffi should be ffi.lib, not libffi.lib
+            replace_in_file(self, os.path.join(self.source_folder, "configure"), "ffi_LIBS=-lffi", "ffi_LIBS=-llibffi")
 
         tc.generate(env)
 

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -22,9 +22,9 @@ class GnustepBaseRecipe(ConanFile):
                   strip_root=True)
 
     def requirements(self):
-        self.requires("gnustep-make/2.9.3")
         self.requires("libobjc2/2.2.1")
         self.requires("libdispatch/6.1.1")
+        self.tool_requires("gnustep-make/2.9.3")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -58,7 +58,7 @@ class GnustepBaseRecipe(ConanFile):
             env.append_path("PATH", os.path.dirname(cc))
             env.append_path("PATH", os.path.dirname(cxx))
 
-        gnustep_make_package_folder = self.dependencies["gnustep-make"].package_folder
+        gnustep_make_package_folder = self.dependencies.build["gnustep-make"].package_folder
 
         # Add gnustep-config to path
         env.append_path("PATH", os.path.join(gnustep_make_package_folder, "bin"))

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -57,18 +57,8 @@ class GnustepBaseRecipe(ConanFile):
         tc = AutotoolsToolchain(self)
         env = tc.environment()
         
-        # On Windows, the path to the the compiler may include spaces (e.g. C:\Program Files\LLVM\bin\clang.exe)
-        # This creates issues in MSYS2.  Instead, set CC/CXX to the executable name only, and include the parent directly
-        # in PATH.
-        vars = self.buildenv.vars(self)
-        
+        # We don't have a gnutls build for Windows, yet
         if self.settings.os == "Windows":
-            cc = vars["CC"]
-            cxx = vars["CXX"]
-            tc.configure_args.append(f"CC={os.path.basename(cc)}")
-            tc.configure_args.append(f"CXX={os.path.basename(cxx)}")
-            env.append_path("PATH", os.path.dirname(cc))
-            env.append_path("PATH", os.path.dirname(cxx))
             tc.configure_args.append("--disable-tls")
 
         gnustep_make_package_folder = self.dependencies.build["gnustep-make"].package_folder

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -44,13 +44,9 @@ class GnustepBaseRecipe(ConanFile):
         if self.settings.os == "Windows":
             self.options.rm_safe("fPIC")
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def build_requirements(self):
         # Require a MSYS2 shell on Windows (for Autotools support)
-        if self._settings_build.os == "Windows":
+        if self.settings.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
@@ -64,7 +60,7 @@ class GnustepBaseRecipe(ConanFile):
         # in PATH.
         vars = self.buildenv.vars(self)
         
-        if self._settings_build.os == "Windows":
+        if self.settings.os == "Windows":
             cc = vars["CC"]
             cxx = vars["CXX"]
             tc.configure_args.append(f"CC={os.path.basename(cc)}")
@@ -76,6 +72,7 @@ class GnustepBaseRecipe(ConanFile):
         gnustep_make_package_folder = self.dependencies.build["gnustep-make"].package_folder
         libdispatch_package_folder = self.dependencies["libdispatch"].package_folder
         iconv_package_folder = self.dependencies["libiconv"].package_folder
+        ffi_package_folder = self.dependencies["libffi"].package_folder
 
         gnustep_makefiles_folder = f"{gnustep_make_package_folder}/share/GNUstep/Makefiles/"
         
@@ -88,10 +85,11 @@ class GnustepBaseRecipe(ConanFile):
         # Add gnustep-config to path
         env.append_path("PATH", os.path.join(gnustep_make_package_folder, "bin"))
 
-        # Add the iconv bin folder to path.  The configure process will generate an
+        # Add the iconv and libffi bin folder to path.  The configure process will generate an
         # executable which uses iconv, and will try to launch it.  This results in
         # iconv-2.dll being loaded, hence the need for it to be in PATH
         env.append_path("PATH", os.path.join(iconv_package_folder, "bin"))
+        env.append_path("PATH", os.path.join(ffi_package_folder, "bin"))
 
         # Resolve GNUstep makefiles
         tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_makefiles_folder}")

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -50,6 +50,7 @@ class GnustepBaseRecipe(ConanFile):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
+                self.tool_requires("pkgconf/[>=2.2]")
 
     def generate(self):
         tc = AutotoolsToolchain(self)
@@ -91,6 +92,10 @@ class GnustepBaseRecipe(ConanFile):
             # thing. (Plus, on Linux, it would be LD_LIBRARY_PATH)
             env.append_path("PATH", os.path.join(self.dependencies["libffi"].package_folder, "bin"))
             env.append_path("PATH", os.path.join(self.dependencies["libiconv"].package_folder, "bin"))
+
+            # The copy of MSYS2 in conancentral doesn't include pkg-config, but we acquired it as a built
+            # tool, so use that
+            env.define("PKG_CONFIG", os.path.join(self.dependencies.build["pkgconf"].package_folder, "bin", "pkgconf.exe"))
 
         # Resolve GNUstep makefiles
         tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_makefiles_folder}")

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -1,0 +1,81 @@
+from conan import ConanFile
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
+from conan.tools.files import get
+from conan.tools.microsoft import unix_path
+import os
+
+class GnustepBaseRecipe(ConanFile):
+    name = "gnustep-base"
+    version = "1.31.1"
+    package_type = "library"
+    license = "LGPL-2.1"
+    url = "https://github.com/gnustep/libs-base"
+    description = "The GNUstep Base Library is a library of general-purpose, non-graphical Objective C objects."
+    
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": True, "fPIC": True}
+
+    def source(self):
+        get(self, "https://github.com/gnustep/libs-base/releases/download/base-1_31_1/gnustep-base-1.31.1.tar.gz",
+                  strip_root=True)
+
+    def requirements(self):
+        self.requires("gnustep-make/2.9.3")
+        self.requires("libobjc2/2.2.1")
+        self.requires("libdispatch/6.1.1")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        # Require a MSYS2 shell on Windows (for Autotools support)
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        env = tc.environment()
+        
+        # On Windows, the path to the the compiler may include spaces (e.g. C:\Program Files\LLVM\bin\clang.exe)
+        # This creates issues in MSYS2.  Instead, set CC/CXX to the executable name only, and include the parent directly
+        # in PATH.
+        vars = self.buildenv.vars(self)
+        
+        if self._settings_build.os == "Windows":
+            cc = vars["CC"]
+            cxx = vars["CXX"]
+            tc.configure_args.append(f"CC={os.path.basename(cc)}")
+            tc.configure_args.append(f"CXX={os.path.basename(cxx)}")
+            env.append_path("PATH", os.path.dirname(cc))
+            env.append_path("PATH", os.path.dirname(cxx))
+
+        gnustep_make_package_folder = self.dependencies["gnustep-make"].package_folder
+
+        # Add gnustep-config to path
+        env.append_path("PATH", os.path.join(gnustep_make_package_folder, "bin"))
+
+        # Resolve GNUstep makefiles
+        tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_make_package_folder}/share/GNUstep/Makefiles/")
+        tc.configure_args.append("--disable-importing-config-file")
+        tc.generate(env)
+
+        deps = AutotoolsDeps(self)
+        deps.generate()
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        autotools = Autotools(self)
+        autotools.install()

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -69,6 +69,7 @@ class GnustepBaseRecipe(ConanFile):
             env.append_path("PATH", os.path.dirname(cxx))
 
         gnustep_make_package_folder = self.dependencies.build["gnustep-make"].package_folder
+        libdispatch_package_folder = self.dependencies["libdispatch"].package_folder
 
         # Add gnustep-config to path
         env.append_path("PATH", os.path.join(gnustep_make_package_folder, "bin"))
@@ -77,6 +78,7 @@ class GnustepBaseRecipe(ConanFile):
         tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_make_package_folder}/share/GNUstep/Makefiles/")
         tc.make_args.append(f"GNUSTEP_MAKEFILES={gnustep_make_package_folder}/share/GNUstep/Makefiles/")
         tc.configure_args.append("--disable-importing-config-file")
+        env.append("LDFLAGS", f"-Wl,-rpath-link={libdispatch_package_folder}/libs/")
         tc.generate(env)
 
         deps = AutotoolsDeps(self)

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -24,6 +24,7 @@ class GnustepBaseRecipe(ConanFile):
         # These patches are maintained at https://github.com/qmfrederik/libs-base/tree/base-1_31_1-PACKAGE
         patch(self, patch_file=os.path.join(self.export_sources_folder, "0001-Support-libcurl-7.61.patch"))
         patch(self, patch_file=os.path.join(self.export_sources_folder, "0002-expose-declarations-in-NSDebug.h-even-when-NDEBUG-is.patch"))
+        patch(self, patch_file=os.path.join(self.export_sources_folder, "0003-Use-PKG_CONFIG-to-invoke-pkg-config.patch"))
 
     def requirements(self):
         self.requires("libobjc2/2.2.1")

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -71,8 +71,6 @@ class GnustepBaseRecipe(ConanFile):
 
         gnustep_make_package_folder = self.dependencies.build["gnustep-make"].package_folder
         libdispatch_package_folder = self.dependencies["libdispatch"].package_folder
-        iconv_package_folder = self.dependencies["libiconv"].package_folder
-        ffi_package_folder = self.dependencies["libffi"].package_folder
 
         gnustep_makefiles_folder = f"{gnustep_make_package_folder}/share/GNUstep/Makefiles/"
         
@@ -85,11 +83,14 @@ class GnustepBaseRecipe(ConanFile):
         # Add gnustep-config to path
         env.append_path("PATH", os.path.join(gnustep_make_package_folder, "bin"))
 
-        # Add the iconv and libffi bin folder to path.  The configure process will generate an
-        # executable which uses iconv, and will try to launch it.  This results in
-        # iconv-2.dll being loaded, hence the need for it to be in PATH
-        env.append_path("PATH", os.path.join(iconv_package_folder, "bin"))
-        env.append_path("PATH", os.path.join(ffi_package_folder, "bin"))
+        if self.settings.os == "Windows":
+            # Add the iconv and libffi bin folder to path.  The configure process will generate an
+            # executable which uses iconv, and will try to launch it.  This results in
+            # iconv-2.dll being loaded, hence the need for it to be in PATH.
+            # These dependencies are sourced from the OS on Linux, so this is a Windows-only
+            # thing. (Plus, on Linux, it would be LD_LIBRARY_PATH)
+            env.append_path("PATH", os.path.join(self.dependencies["libffi"].package_folder, "bin"))
+            env.append_path("PATH", os.path.join(self.dependencies["libiconv"].package_folder, "bin"))
 
         # Resolve GNUstep makefiles
         tc.configure_args.append(f"GNUSTEP_MAKEFILES={gnustep_makefiles_folder}")

--- a/gnustep-base/conanfile.py
+++ b/gnustep-base/conanfile.py
@@ -28,6 +28,12 @@ class GnustepBaseRecipe(ConanFile):
     def requirements(self):
         self.requires("libobjc2/2.2.1")
         self.requires("libdispatch/6.1.1")
+        self.requires("libffi/3.4.8")
+        self.requires("libxml2/2.13.8")
+        self.requires("libxslt/1.1.43")
+        self.requires("gnutls/3.8.7")
+        self.requires("icu/77.1")
+        self.requires("libcurl/8.12.1")
         self.tool_requires("gnustep-make/2.9.3")
 
     def config_options(self):

--- a/profiles/linux-clang
+++ b/profiles/linux-clang
@@ -17,3 +17,4 @@ libxslt/1.1.43
 gnutls/3.8.7
 icu/77.1
 libcurl/8.12.1
+libiconv/1.17

--- a/profiles/linux-clang
+++ b/profiles/linux-clang
@@ -9,3 +9,11 @@ compiler=clang
 compiler.cppstd=gnu17
 compiler.version=18
 os=Linux
+
+[platform_requires]
+libffi/3.4.8
+libxml2/2.13.8
+libxslt/1.1.43
+gnutls/3.8.7
+icu/77.1
+libcurl/8.12.1

--- a/profiles/windows-clang
+++ b/profiles/windows-clang
@@ -36,3 +36,6 @@ gnustep-*/*:compiler.runtime_version=v144
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 tools.build:compiler_executables = {"c": "clang", "cpp": "clang++"}
+
+[platform_requires]
+icu/77.1

--- a/profiles/windows-clang
+++ b/profiles/windows-clang
@@ -33,12 +33,6 @@ gnustep-*/*:compiler.runtime_version=v144
 [options]
 *:shared=True
 
-[options]
-libxml2/*:shared=True
-libxslt/*:shared=True
-libiconv/*:shared=True
-zlib/*:shared=True
-
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 tools.build:compiler_executables = {"c": "clang", "cpp": "clang++"}

--- a/profiles/windows-clang
+++ b/profiles/windows-clang
@@ -33,6 +33,12 @@ gnustep-*/*:compiler.runtime_version=v144
 [options]
 *:shared=True
 
+[options]
+libxml2/*:shared=True
+libxslt/*:shared=True
+libiconv/*:shared=True
+zlib/*:shared=True
+
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 tools.build:compiler_executables = {"c": "clang", "cpp": "clang++"}


### PR DESCRIPTION
- Package gnustep-base for Linux and Windows
- Use system-provided packages on Windows
- Update the Conan profile to use msvc and shared libraries by default on Windows, add an exception to use clang for all packages in this repo
- Add VS Code tasks for building the individual packages