### PR TITLE
gnustep-make: Add libobjc2 dependency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,20 @@
             "justMyCode": false,
             "args": [
                 "create",
-                "${workspaceFolder}/libdispatch/conanfile.py"
+                "${workspaceFolder}/libdispatch/conanfile.py",
+                "--profile:a=${workspaceFolder}/profiles/linux-clang"
+            ],
+        },
+        {
+            "name": "gnustep-make",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "conans.conan",
+            "justMyCode": false,
+            "args": [
+                "create",
+                "${workspaceFolder}/gnustep-make/conanfile.py",
+                "--profile:a=${workspaceFolder}/profiles/linux-clang"
             ],
         }
     ]

--- a/gnustep-make/conanfile.py
+++ b/gnustep-make/conanfile.py
@@ -21,6 +21,9 @@ class GnustepMakeRecipe(ConanFile):
         get(self, "https://github.com/gnustep/tools-make/releases/download/make-2_9_3/gnustep-make-2.9.3.tar.gz",
                   strip_root=True)
 
+    def requirements(self):
+        self.requires("libobjc2/2.2.1")
+
     def config_options(self):
         if self.settings.os == "Windows":
             self.options.rm_safe("fPIC")

--- a/libobjc2/conanfile.py
+++ b/libobjc2/conanfile.py
@@ -51,6 +51,3 @@ class libobjc2Recipe(ConanFile):
         cmake = CMake(self)
         cmake.install()
 
-    def package_info(self):
-        self.cpp_info.libs = ["libobjc2"]
-


### PR DESCRIPTION
Also, don't export an invalid libname from libobjc2 itself