### PR TITLE
tools-make: Force windows target

### DIFF
--- a/gnustep-make/conanfile.py
+++ b/gnustep-make/conanfile.py
@@ -46,18 +46,30 @@ class GnustepMakeRecipe(ConanFile):
         tc.configure_args.append("--with-runtime-abi=gnustep-2.2")
         env.append("LDFLAGS", "-fuse-ld=lld")
         
-        # On Windows, the path to the the compiler may include spaces (e.g. C:\Program Files\LLVM\bin\clang.exe)
-        # This creates issues in MSYS2.  Instead, set CC/CXX to the executable name only, and include the parent directly
-        # in PATH.
         vars = self.buildenv.vars(self)
         
         if self._settings_build.os == "Windows":
+            # On Windows, the path to the the compiler may include spaces (e.g. C:\Program Files\LLVM\bin\clang.exe)
+            # This creates issues in MSYS2.  Instead, set CC/CXX to the executable name only, and include the parent directly
+            # in PATH.
             cc = vars["CC"]
             cxx = vars["CXX"]
             tc.configure_args.append(f"CC={os.path.basename(cc)}")
             tc.configure_args.append(f"CXX={os.path.basename(cxx)}")
             env.append_path("PATH", os.path.dirname(cc))
             env.append_path("PATH", os.path.dirname(cxx))
+
+            # On Windows, force targetting native Windows, even when building in an MSYS2 shell (we're somewhat cross-compiling
+            # from MSYS2 to native Windows, even though we're using the _native_ tooling within MSYS2).
+            # If these variables are not set, gnustep-make will include -lm in the libs used when compiling, resulting in a
+            # compiler error when building gnustep-base.
+            #
+            # The output in configure logs for tools-make should be like this:
+            # checking build system type... x86_64-w64-mingw32
+            # checking host system type... x86_64-pc-windows
+            # checking target system type... x86_64-pc-windows
+            tc.configure_args.append(f"--host=x86_64-pc-windows")
+            tc.configure_args.append(f"--target=x86_64-pc-windows")
 
         tc.generate(env)
 


### PR DESCRIPTION
On Windows, force targetting native Windows, even when building in an MSYS2 shell (we're somewhat cross-compiling
from MSYS2 to native Windows, even though we're using the _native_ tooling within MSYS2).
If these variables are not set, gnustep-make will include -lm in the libs used when compiling, resulting in a
compiler error when building gnustep-base.