### PR TITLE
Move compiler configuration to the Conan profile, default to msvc

### DIFF
--- a/gnustep-make/conanfile.py
+++ b/gnustep-make/conanfile.py
@@ -46,19 +46,7 @@ class GnustepMakeRecipe(ConanFile):
         tc.configure_args.append("--with-runtime-abi=gnustep-2.2")
         env.append("LDFLAGS", "-fuse-ld=lld")
         
-        vars = self.buildenv.vars(self)
-        
         if self._settings_build.os == "Windows":
-            # On Windows, the path to the the compiler may include spaces (e.g. C:\Program Files\LLVM\bin\clang.exe)
-            # This creates issues in MSYS2.  Instead, set CC/CXX to the executable name only, and include the parent directly
-            # in PATH.
-            cc = vars["CC"]
-            cxx = vars["CXX"]
-            tc.configure_args.append(f"CC={os.path.basename(cc)}")
-            tc.configure_args.append(f"CXX={os.path.basename(cxx)}")
-            env.append_path("PATH", os.path.dirname(cc))
-            env.append_path("PATH", os.path.dirname(cxx))
-
             # On Windows, force targetting native Windows, even when building in an MSYS2 shell (we're somewhat cross-compiling
             # from MSYS2 to native Windows, even though we're using the _native_ tooling within MSYS2).
             # If these variables are not set, gnustep-make will include -lm in the libs used when compiling, resulting in a

--- a/profiles/windows-clang
+++ b/profiles/windows-clang
@@ -1,16 +1,38 @@
 [buildenv]
-CC=C:\Program Files\LLVM\bin\clang.exe
-CXX=C:\Program Files\LLVM\bin\clang++.exe
+PATH=+(path)C:\Program Files\LLVM\bin
 
 [settings]
 arch=x86_64
 build_type=Release
-compiler=clang
-compiler.cppstd=17
+
+compiler=msvc
+compiler.runtime=msvc
+compiler.version=194
 compiler.runtime=dynamic
-compiler.version=20
-compiler.runtime_version=v144
+compiler.runtime_type=Release
 os=Windows
+
+libobjc2/*:compiler=clang
+libobjc2/*:compiler.cppstd=17
+libobjc2/*:compiler.runtime=dynamic
+libobjc2/*:compiler.version=20
+libobjc2/*:compiler.runtime_version=v144
+
+libdispatch/*:compiler=clang
+libdispatch/*:compiler.cppstd=17
+libdispatch/*:compiler.runtime=dynamic
+libdispatch/*:compiler.version=20
+libdispatch/*:compiler.runtime_version=v144
+
+gnustep-*/*:compiler=clang
+gnustep-*/*:compiler.cppstd=17
+gnustep-*/*:compiler.runtime=dynamic
+gnustep-*/*:compiler.version=20
+gnustep-*/*:compiler.runtime_version=v144
+
+[options]
+*:shared=True
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
+tools.build:compiler_executables = {"c": "clang", "cpp": "clang++"}


### PR DESCRIPTION
- No need to fiddle with CC/CXX/PATH in conanfile.py
- Use prebuilt msvc dependencies