### PR TITLE
libdispatch: Don't use vcenvvars

### DIFF
--- a/profiles/windows-clang
+++ b/profiles/windows-clang
@@ -21,9 +21,7 @@ libobjc2/*:compiler.runtime_version=v144
 
 libdispatch/*:compiler=clang
 libdispatch/*:compiler.cppstd=17
-libdispatch/*:compiler.runtime=dynamic
 libdispatch/*:compiler.version=20
-libdispatch/*:compiler.runtime_version=v144
 
 gnustep-*/*:compiler=clang
 gnustep-*/*:compiler.cppstd=17


### PR DESCRIPTION
Compiler errors occur when compiling libdispatch using the Visual C++ system headers, such as about `memory_order_relaxed` not being defined.  This appears to be because the Visual C++ system headers don't define this enum or don't define this enum in the same header.

The build system will pick up the Visual C++ system headers if the `compiler.runtime` and `compiler.runtime_version` values are set (by virtue of the `VCVars` generator, which is used implicitly by the CMake generator, see https://github.com/conan-io/conan/blob/9826fbd57f43b847d22d4530dfe40f015f4dc9e5/conan/tools/microsoft/visual.py#L302).

If `compiler.runtime` and `compiler.runtime_version` is not set, `VCVars` will not run, and the Visual C++ system headers are not picked up.  Instead, the Clang headers will be used, which define `memory_order_relaxed` the way libdispatch expects it.